### PR TITLE
fix: reIssue 토큰 로직 수정

### DIFF
--- a/services/admin/src/apis/index.ts
+++ b/services/admin/src/apis/index.ts
@@ -1,4 +1,8 @@
-import axios, { AxiosError } from 'axios';
+import axios, {
+  AxiosError,
+  AxiosHeaders,
+  InternalAxiosRequestConfig,
+} from 'axios';
 import { reIssueToken } from '@/apis/auth';
 import { getCookie, setCookie } from '@/utils/cookies';
 
@@ -7,51 +11,98 @@ export const instance = axios.create({
   timeout: 10000,
 });
 
+let isRefreshing = false;
+let refreshSubscribers: ((token: string) => void)[] = [];
+
+const hasMessage = (data: any): data is { message: string } => {
+  return typeof data === 'object' && data !== null && 'message' in data;
+};
+
+const onRefreshed = (token: string) => {
+  refreshSubscribers.forEach((callback) => callback(token));
+  refreshSubscribers = [];
+};
+
 instance.interceptors.request.use(
   (config) => {
     const accessToken = getCookie('access_token');
-    const returnConfig = {
-      ...config,
-    };
     if (accessToken) {
-      //@ts-ignore
-      returnConfig.headers = {
+      config.headers = new AxiosHeaders({
+        ...config.headers,
         Authorization: `Bearer ${accessToken}`,
-      };
+      });
     }
-    return returnConfig;
+    return config;
   },
   (error: AxiosError) => Promise.reject(error),
 );
 
 instance.interceptors.response.use(
   (response) => response,
-  (error: AxiosError<AxiosError>) => {
-    if (axios.isAxiosError(error) && error.response) {
-      const { config } = error;
+  async (error: AxiosError) => {
+    const originalRequest = error.config as InternalAxiosRequestConfig & {
+      _retry?: boolean;
+    };
+
+    if (
+      axios.isAxiosError(error) &&
+      error.response?.data &&
+      hasMessage(error.response.data) &&
+      error.response.data.message === 'Expired Token'
+    ) {
       const refreshToken = getCookie('refresh_token');
-      if (error.response.data.message === 'Expired Token') {
-        if (refreshToken) {
-          reIssueToken(refreshToken).then((res) => {
-            const accessExpired = new Date(res.access_token_expired_at);
-            const refreshExpired = new Date(res.refresh_token_expired_at);
 
-            setCookie('access_token', res.access_token, {
-              expires: accessExpired,
+      if (!refreshToken) {
+        window.location.href = '/login';
+        return Promise.reject(error);
+      }
+
+      if (originalRequest._retry) {
+        return Promise.reject(error);
+      }
+      originalRequest._retry = true;
+
+      if (isRefreshing) {
+        return new Promise((resolve) => {
+          refreshSubscribers.push((token: string) => {
+            originalRequest.headers = new AxiosHeaders({
+              ...originalRequest.headers,
+              Authorization: `Bearer ${token}`,
             });
-
-            setCookie('refresh_token', res.refresh_token, {
-              expires: refreshExpired,
-            });
-
-            if (config.headers)
-              config.headers['Authorization'] = `Bearer ${res.access_token}`;
-            return axios(config);
+            resolve(instance(originalRequest));
           });
-        } else {
-          window.location.href = '/login';
-        }
-      } else return Promise.reject(error);
+        });
+      }
+
+      isRefreshing = true;
+
+      try {
+        const res = await reIssueToken(refreshToken);
+        const newAccessToken = res.access_token;
+
+        setCookie('access_token', newAccessToken, {
+          expires: new Date(res.access_token_expired_at),
+        });
+
+        setCookie('refresh_token', res.refresh_token, {
+          expires: new Date(res.refresh_token_expired_at),
+        });
+
+        isRefreshing = false;
+        onRefreshed(newAccessToken);
+
+        originalRequest.headers = new AxiosHeaders({
+          ...originalRequest.headers,
+          Authorization: `Bearer ${newAccessToken}`,
+        });
+        return instance(originalRequest);
+      } catch (err) {
+        isRefreshing = false;
+        window.location.href = '/login';
+        return Promise.reject(err);
+      }
     }
+
+    return Promise.reject(error);
   },
 );

--- a/services/admin/src/apis/index.ts
+++ b/services/admin/src/apis/index.ts
@@ -44,12 +44,7 @@ instance.interceptors.response.use(
       _retry?: boolean;
     };
 
-    if (
-      axios.isAxiosError(error) &&
-      error.response?.data &&
-      hasMessage(error.response.data) &&
-      error.response.data.message === 'Expired Token'
-    ) {
+    if (error.response.status === 401 || error.response.status === 403) {
       const refreshToken = getCookie('refresh_token');
 
       if (!refreshToken) {


### PR DESCRIPTION
## 개요 
api 로직 수정

## 이슈 번호

- closes #123 

## 변경사항 
isRefreshing 을 추가하여 isRefreshing === true 라면 토큰을 공유하고 기존 요청을 다시 하도록 설정
이미 reIssue 요청이 진행중이면 refreshSubscribers 배열에 기존 요청을 저장해 두고, reIssue가 완료되면 한꺼번에 재시도
refrash_token도 만료된 상태라면 로그인 페이지로 사용자를 보냄

